### PR TITLE
chore: switch license from MIT to CC BY-NC 4.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,38 @@
+Creative Commons Attribution-NonCommercial 4.0 International
+
+Copyright (c) 2026 Agents365-ai
+
+This work is licensed under the Creative Commons
+Attribution-NonCommercial 4.0 International License.
+
+You are free to:
+
+  Share — copy and redistribute the material in any medium or format
+  Adapt — remix, transform, and build upon the material
+
+Under the following terms:
+
+  Attribution — You must give appropriate credit, provide a link to
+  the license, and indicate if changes were made. You may do so in
+  any reasonable manner, but not in any way that suggests the licensor
+  endorses you or your use.
+
+  NonCommercial — You may not use the material for commercial purposes.
+
+  No additional restrictions — You may not apply legal terms or
+  technological measures that legally restrict others from doing
+  anything the license permits.
+
+Notices:
+
+  You do not have to comply with the license for elements of the
+  material in the public domain or where your use is permitted by
+  an applicable exception or limitation.
+
+  No warranties are given. The license may not give you all of the
+  permissions necessary for your intended use. For example, other
+  rights such as publicity, privacy, or moral rights may limit how
+  you use the material.
+
+For the full license text, see:
+https://creativecommons.org/licenses/by-nc/4.0/legalcode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "zotero-rag-cli"
 version = "0.5.0"
 description = "rak — Semantic search over your Zotero library"
 requires-python = ">=3.10"
-license = "MIT"
+license = "CC-BY-NC-4.0"
 readme = "README.md"
 authors = [
     { name = "Agents365-ai" },
@@ -12,7 +12,7 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Console",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
+    "License :: Other/Proprietary License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
## Summary
- Add LICENSE file with Creative Commons Attribution-NonCommercial 4.0 International
- Update pyproject.toml license field from MIT to CC-BY-NC-4.0
- Update classifier to "License :: Other/Proprietary License" (CC-BY-NC is not OSI-approved)

## Test plan
- [ ] Verify LICENSE file renders correctly on GitHub
- [ ] Verify pyproject.toml metadata is valid